### PR TITLE
Use `he` for robust HTML entity encoding/decoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var ent = require('ent');
+var he = require('he');
 var marked = require('marked');
 var renderer = new marked.Renderer();
 
@@ -8,12 +8,12 @@ renderer.code = function(code, language) {
 	return '';
 };
 renderer.blockquote = function(quote) {
-	quote = ent.decode(quote);
+	quote = he.decode(quote);
 	return '"' + quote.trim() + '" ';
 };
 //html(string html)
 renderer.heading = function(text, level) {
-	text = ent.decode(text);
+	text = he.decode(text);
 	return text + ': ';
 };
 //hr()
@@ -21,7 +21,7 @@ renderer.list = function(body, ordered) {
 	return body.trim();
 };
 renderer.listitem = function(text) {
-	text = ent.decode(text);
+	text = he.decode(text);
 	if (/\.\s*$/.test(text)) {
 		return text;
 	}
@@ -34,7 +34,7 @@ renderer.paragraph = function(text) {
 	if (text === '') {
 		return '';
 	}
-	text = ent.decode(text);
+	text = he.decode(text);
 	return text + ' ';
 };
 //table(string header, string body)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "bryanburgers/summarize-markdown"
   },
   "dependencies": {
-    "ent": "~0.1.0",
+    "he": "~0.4.1",
     "marked": "~0.3"
   },
   "devDependencies": {

--- a/test/summary.js
+++ b/test/summary.js
@@ -69,6 +69,10 @@ describe('summarize', function() {
 		t('First content.\r\n\r\n![Alt](/assets/images/image.png)\r\n\r\nSome other content.', 'First content. Some other content.');
 	});
 
+	it('decodes HTML character references correctly', function() {
+		t('> foo &#x1D306; bar &amp; baz', '"foo \uD834\uDF06 bar & baz"');
+	});
+
 	it('ignores code', function() {
 		t('First content.\r\n\r\n```js\r\nvar x = 3;\r\nvar y = 4;\r\n```\r\n\r\nSome other content.', 'First content. Some other content.');
 	});


### PR DESCRIPTION
_ent_ has [several open issues](https://github.com/substack/node-ent/issues/created_by/mathiasbynens?state=open) that are not present in [_he_](http://mths.be/he).
